### PR TITLE
Add baseUrl to script path for ember-cli-live-reload.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,9 +5,10 @@ module.exports = {
 
   contentFor: function(type) {
     var liveReloadPort = process.env.EMBER_CLI_INJECT_LIVE_RELOAD_PORT;
+    var baseURL = process.env.EMBER_CLI_INJECT_LIVE_RELOAD_BASEURL;
 
     if (liveReloadPort && type === 'head') {
-      return '<script src="/ember-cli-live-reload.js" type="text/javascript"></script>';
+      return '<script src="' + baseURL + 'ember-cli-live-reload.js" type="text/javascript"></script>';
     }
   },
 
@@ -31,8 +32,9 @@ module.exports = {
     if (options.liveReload !== true) { return; }
 
     process.env.EMBER_CLI_INJECT_LIVE_RELOAD_PORT = options.liveReloadPort;
+    process.env.EMBER_CLI_INJECT_LIVE_RELOAD_BASEURL = options.baseURL; // default is '/'
 
-    app.use('/ember-cli-live-reload.js', function(request, response, next) {
+    app.use(options.baseURL + 'ember-cli-live-reload.js', function(request, response, next) {
       response.contentType('text/javascript');
       response.send(self.dynamicScript());
     });


### PR DESCRIPTION
Path to the dynamic script returned via a script request for /ember-cli-live-reload.js needed to use the baseURL set in the ember-cli application's config/environment (default is '/'). So support is needed to include the baseURL in the live-reload (dynamic) script like so: /path-to-your-ember-app-base-url/ember-cli-live-reload.js

Given a custom url using ENV.baseURL like `/mydirectory/` (or the default `'/'`)
When running the development server on port 4200
Then the dynamic live-reload script should be served from the baseUrl + ember-cli-live-reload.js

[Fixes #15]