### PR TITLE
Add option to detect the live reload script origin

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,22 +1,34 @@
 'use strict';
 
+var util = require('util');
+
 module.exports = {
   name: 'live-reload-middleware',
 
   contentFor: function(type) {
     var liveReloadPort = process.env.EMBER_CLI_INJECT_LIVE_RELOAD_PORT;
     var baseURL = process.env.EMBER_CLI_INJECT_LIVE_RELOAD_BASEURL;
+    var origin = process.env.EMBER_CLI_INJECT_LIVE_RELOAD_ORIGIN;
 
     if (liveReloadPort && type === 'head') {
-      return '<script src="' + baseURL + 'ember-cli-live-reload.js" type="text/javascript"></script>';
+      return '<script src="' + (origin || baseURL) + 'ember-cli-live-reload.js"></script>';
     }
   },
 
   dynamicScript: function(request) {
-    var liveReloadPort = process.env.EMBER_CLI_INJECT_LIVE_RELOAD_PORT;
+    var port = process.env.EMBER_CLI_INJECT_LIVE_RELOAD_PORT;
+    var host = process.env.EMBER_CLI_INJECT_LIVE_RELOAD_HOST;
+    var resource = 'livereload.js?snipver=1';
+
+    var scriptSrc;
+    if (host) {
+      scriptSrc = util.format("'http://%s:%d/%s'", host, port, resource);
+    } else {
+      scriptSrc = util.format("(location.protocol || 'http:') + '//' + (location.hostname || 'localhost') + ':%d/%s'", port, resource);
+    }
 
     return "(function() {\n " +
-           "var src = (location.protocol || 'http:') + '//' + (location.hostname || 'localhost') + ':" + liveReloadPort + "/livereload.js?snipver=1';\n " +
+           "var src = " + scriptSrc + ";\n " +
            "var script    = document.createElement('script');\n " +
            "script.type   = 'text/javascript';\n " +
            "script.src    = src;\n " +
@@ -32,7 +44,12 @@ module.exports = {
     if (options.liveReload !== true) { return; }
 
     process.env.EMBER_CLI_INJECT_LIVE_RELOAD_PORT = options.liveReloadPort;
-    process.env.EMBER_CLI_INJECT_LIVE_RELOAD_BASEURL = options.baseURL; // default is '/'
+    process.env.EMBER_CLI_INJECT_LIVE_RELOAD_BASEURL = options.baseURL;
+
+    if (options.detectLiveReloadOrigin === true) {
+      process.env.EMBER_CLI_INJECT_LIVE_RELOAD_HOST = options.host;
+      process.env.EMBER_CLI_INJECT_LIVE_RELOAD_ORIGIN = util.format('http://%s:%d/', options.host, options.port);
+    }
 
     app.use(options.baseURL + 'ember-cli-live-reload.js', function(request, response, next) {
       response.contentType('text/javascript');


### PR DESCRIPTION
I'd like to improve the way we can handle live reload in an Ember CLI + NW.js (Node WebKit) app. I know the `baseURL` option was recently added, but I need slightly more flexibility. With just another configuration option, this addon can actually be used in that environment.

NW.js typically loads the main html page using the `file://` protocol. Because of the way the addon is currently configured, the script that gets injected into the page via `contentFor` ends up making a request to `file:///ember-cli-live-reload.js`, which of course doesn't exist.

During development, I still use `ember s` to watch and rebuild all assets, and even though `localhost:4200` is not serving those assets, it could still be used to serve the live reload script (granted, we are now talking about loading content from different origins, but I feel it's acceptable in this controlled environment, and it's only for development).

Similarly, the `dynamicScript` method always looks for `location.protocol` and `location.hostname`. In order to make this work for NW.js, the origin for the script would also need to be configurable.

This PR introduces a new configuration option for the addon, called `detectLiveReloadOrigin`. If specified and set to `true`, the existing `options.host` and `options.port` are used to determine where to request the live reload script. I've tested it out locally and it works well in both Node WebKit and the browser.

Would love to get your feedback on this. Thanks!