### PR TITLE
Allow forcing localhost when not using Ember-CLI to serve project

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,6 +35,9 @@ module.exports = {
     process.env.EMBER_CLI_INJECT_LIVE_RELOAD_BASEURL = options.baseURL; // default is '/'
     process.env.EMBER_CLI_INJECT_LIVE_RELOAD_FORCE_LOCALHOST = options.liveReloadForceLocalhost;
 
+    if (options.liveReloadForceLocalhost) {
+      process.env.EMBER_CLI_INJECT_LIVE_RELOAD_BASEURL = 'http://localhost:' + options.port + options.baseURL;
+    }
 
     app.use(options.baseURL + 'ember-cli-live-reload.js', function(request, response, next) {
       response.contentType('text/javascript');

--- a/index.js
+++ b/index.js
@@ -33,6 +33,8 @@ module.exports = {
 
     process.env.EMBER_CLI_INJECT_LIVE_RELOAD_PORT = options.liveReloadPort;
     process.env.EMBER_CLI_INJECT_LIVE_RELOAD_BASEURL = options.baseURL; // default is '/'
+    process.env.EMBER_CLI_INJECT_LIVE_RELOAD_FORCE_LOCALHOST = options.liveReloadForceLocalhost;
+
 
     app.use(options.baseURL + 'ember-cli-live-reload.js', function(request, response, next) {
       response.contentType('text/javascript');

--- a/index.js
+++ b/index.js
@@ -14,9 +14,16 @@ module.exports = {
 
   dynamicScript: function(request) {
     var liveReloadPort = process.env.EMBER_CLI_INJECT_LIVE_RELOAD_PORT;
+    var forceLocalhost = process.env.EMBER_CLI_INJECT_LIVE_RELOAD_FORCE_LOCALHOST;
+
+    var dynamicHost = "location.hostname || 'localhost'";
+
+    if (forceLocalhost) {
+      dynamicHost = "'localhost'";
+    }
 
     return "(function() {\n " +
-           "var src = (location.protocol || 'http:') + '//' + (location.hostname || 'localhost') + ':" + liveReloadPort + "/livereload.js?snipver=1';\n " +
+           "var src = (location.protocol || 'http:') + '//' + (" + dynamicHost + ") + ':" + liveReloadPort + "/livereload.js?snipver=1';\n " +
            "var script    = document.createElement('script');\n " +
            "script.type   = 'text/javascript';\n " +
            "script.src    = src;\n " +


### PR DESCRIPTION
Related to issue #13 -

We don't use ember-cli to serve our dist/ directory.  We also use a non-standard local hostname.

This change adds a `liveReloadForceLocalhost` option to force the addon to expect the livereload script on a fully-qualified localhost URL (rather than a relative path).  

Ember-CLI's `baseURL` and `port` options are respected.  

It could be further generalized to be more customizable, but my assumption is that CLI will really only be used on localhost. Since there's already a semi-hardcode (`location.hostname || 'localhost'`), this seems reasonable to me.  

To use,
```json
# file .ember-cli
{
  "liveReloadForceLocalhost": true
}
```


Seems to be working for us - let me know what you think!
Thanks,
-david