### PR TITLE
Simplify livereload injection by removing the script.

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,39 +4,22 @@ module.exports = {
   name: 'live-reload-middleware',
 
   contentFor: function(type) {
-    var liveReloadPort = process.env.EMBER_CLI_INJECT_LIVE_RELOAD_PORT;
-    var baseURL = process.env.EMBER_CLI_INJECT_LIVE_RELOAD_BASEURL;
+    var liveReloadScriptSrc = process.env.EMBER_CLI_INJECT_LIVE_RELOAD_SCRIPT_SRC;
 
-    if (liveReloadPort && type === 'head') {
-      return '<script src="' + baseURL + 'ember-cli-live-reload.js" type="text/javascript"></script>';
+    if (liveReloadScriptSrc && type === 'head') {
+      return '<script src="' + liveReloadScriptSrc + '" type="text/javascript"></script>';
     }
   },
-
-  dynamicScript: function(request) {
-    var liveReloadPort = process.env.EMBER_CLI_INJECT_LIVE_RELOAD_PORT;
-
-    return "(function() {\n " +
-           "var src = (location.protocol || 'http:') + '//' + (location.hostname || 'localhost') + ':" + liveReloadPort + "/livereload.js?snipver=1';\n " +
-           "var script    = document.createElement('script');\n " +
-           "script.type   = 'text/javascript';\n " +
-           "script.src    = src;\n " +
-           "document.getElementsByTagName('head')[0].appendChild(script);\n" +
-           "}());";
-  },
-
   serverMiddleware: function(config) {
-    var self = this;
-    var app = config.app;
     var options = config.options;
 
     if (options.liveReload !== true) { return; }
 
-    process.env.EMBER_CLI_INJECT_LIVE_RELOAD_PORT = options.liveReloadPort;
-    process.env.EMBER_CLI_INJECT_LIVE_RELOAD_BASEURL = options.baseURL; // default is '/'
+    var liveReloadHost = options.liveReloadHost || options.host;
 
-    app.use(options.baseURL + 'ember-cli-live-reload.js', function(request, response, next) {
-      response.contentType('text/javascript');
-      response.send(self.dynamicScript());
-    });
+    var scheme = options.ssl ? 'https://' : 'http://';
+    var src = [scheme, liveReloadHost, ':', options.liveReloadPort, '/livereload.js?snipver=1'].join('');
+
+    process.env.EMBER_CLI_INJECT_LIVE_RELOAD_SCRIPT_SRC = src;
   }
 };


### PR DESCRIPTION
This is one approach at solving #22 and #13.

This PR removes the dynamically generated script, and
loads it from the livereload server directly.

It introduces a new configuration variable `options.liveReloadHost`
and will take into account `options.ssl` to avoid mixed content
warnings.

I'm not how to propagate options.liveReloadHost, but I assume you folks can
help with that.