### PR TITLE
Allow to force baseURL

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,9 @@ module.exports = {
     if (options.liveReload !== true) { return; }
 
     process.env.EMBER_CLI_INJECT_LIVE_RELOAD_PORT = options.liveReloadPort;
-    process.env.EMBER_CLI_INJECT_LIVE_RELOAD_BASEURL = options.baseURL; // default is '/'
+    if (process.env.EMBER_CLI_INJECT_LIVE_RELOAD_BASEURL === undefined) {
+      process.env.EMBER_CLI_INJECT_LIVE_RELOAD_BASEURL = options.baseURL; // default is '/'  
+    }
 
     app.use(options.baseURL + 'ember-cli-live-reload.js', function(request, response, next) {
       response.contentType('text/javascript');

--- a/index.js
+++ b/index.js
@@ -32,9 +32,7 @@ module.exports = {
     if (options.liveReload !== true) { return; }
 
     process.env.EMBER_CLI_INJECT_LIVE_RELOAD_PORT = options.liveReloadPort;
-    if (process.env.EMBER_CLI_INJECT_LIVE_RELOAD_BASEURL === undefined) {
-      process.env.EMBER_CLI_INJECT_LIVE_RELOAD_BASEURL = options.baseURL; // default is '/'  
-    }
+    process.env.EMBER_CLI_INJECT_LIVE_RELOAD_BASEURL = options.liveReloadBaseUrl || options.baseURL;
 
     app.use(options.baseURL + 'ember-cli-live-reload.js', function(request, response, next) {
       response.contentType('text/javascript');


### PR DESCRIPTION
Does not override EMBER_CLI_INJECT_LIVE_RELOAD_BASEURL if already defined.

This allows an independent development server (not the express one bundled with ember-cli)  to serve several apps while being live-reloaded.