### PR TITLE
Fix overriding baseURL

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,8 @@ module.exports = {
     var self = this;
     var app = config.app;
     var options = config.options;
-    var baseURL = options.liveReloadBaseUrl || options.baseURL;
+    // maintaining `baseURL` for backwards compatibility. See: http://emberjs.com/blog/2016/04/28/baseURL.html
+    var baseURL = options.liveReloadBaseUrl || options.rootURL || options.baseURL;
 
     if (options.liveReload !== true) { return; }
 

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ module.exports = {
     process.env.EMBER_CLI_INJECT_LIVE_RELOAD_PORT = options.liveReloadPort;
     process.env.EMBER_CLI_INJECT_LIVE_RELOAD_BASEURL = baseURL;
 
-    app.use(options.baseURL + 'ember-cli-live-reload.js', function(request, response, next) {
+    app.use(baseURL + 'ember-cli-live-reload.js', function(request, response, next) {
       response.contentType('text/javascript');
       response.send(self.dynamicScript());
     });

--- a/index.js
+++ b/index.js
@@ -28,11 +28,12 @@ module.exports = {
     var self = this;
     var app = config.app;
     var options = config.options;
+    var baseURL = options.liveReloadBaseUrl || options.baseURL;
 
     if (options.liveReload !== true) { return; }
 
     process.env.EMBER_CLI_INJECT_LIVE_RELOAD_PORT = options.liveReloadPort;
-    process.env.EMBER_CLI_INJECT_LIVE_RELOAD_BASEURL = options.liveReloadBaseUrl || options.baseURL;
+    process.env.EMBER_CLI_INJECT_LIVE_RELOAD_BASEURL = baseURL;
 
     app.use(options.baseURL + 'ember-cli-live-reload.js', function(request, response, next) {
       response.contentType('text/javascript');


### PR DESCRIPTION
Partially fixes #27 by allowing to override baseURL, which is being removed from ember-cli 2.7 (currently in beta).